### PR TITLE
√や(の前に数字がある場合掛け算として計算する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,6 +103,14 @@ export default {
         this.output = this.output * 110 / 100
       }else if (num == 'tax8'){
         this.output = this.output * 108 / 100
+      }else if (num == '(' || num == '√'){
+        const lastNum = this.output.slice(-1)
+        console.log(lastNum)
+        if (!isNaN(lastNum)) {
+          this.output = this.output + '×' + num
+        }else if (lastNum == '-') {
+          this.output = this.output + num          
+        }
       }else if (num != '='){
         this.output = this.output += num
       }else{


### PR DESCRIPTION
# WHAT
計算機能修正

# WHY
7(1+1)のような計算の時にエラーとなっていたため
7(1+1)なら7×(1+1)となるように修正した